### PR TITLE
reapply file sorting after folder switch and make it easier to initializ

### DIFF
--- a/R/filechoose.R
+++ b/R/filechoose.R
@@ -189,13 +189,16 @@ shinyFileChoose <- function(input, id, updateFreq=2000, session, ...) {
 #' For users wanting to design their html markup manually it is very easy to add
 #' a shinyFiles button. The only markup required is:
 #' 
-#' \code{<button id="inputId" type="button" class="shinyFiles btn" data-title="title" data-selecttype="single"|"multiple" data-folderselect="allowed"|"forbidden">label</button>}
+#' \code{<button id="inputId" type="button" class="shinyFiles btn" data-title="title" data-selecttype="single"|"multiple" data-folderselect="allowed"|"forbidden" data-sortby="Name"|"Type"|"Size"|"Created"|"Modified" data-sortdirection="ascending"|"descending">label</button>}
 #' 
 #' where the id tag matches the inputId parameter, the data-title tag matches 
 #' the title parameter, the data-selecttype is either "single" or "multiple" (
 #' the non-logical form of the multiple parameter), the data-folderselect is 
 #' either "allowed" or "forbidden" (non-logical form of the folder_select
-#' parameter) and the internal textnode matches the label parameter.
+#' parameter), the data-sortby defines the attribute to sort by ("Name",
+#' "Type", "Size", "Created" or "Modified"), the data-sortdirection the
+#' sorting direction ("ascending" or "descending") and the internal textnode 
+#' matches the label parameter.
 #' 
 #' Apart from this the html document should link to a script with the 
 #' following path 'sF/shinyFiles.js' and a stylesheet with the following path 
@@ -233,6 +236,13 @@ shinyFileChoose <- function(input, id, updateFreq=2000, session, ...) {
 #' folder_select = TRUE in combination with multiple = TRUE, multiple folders as 
 #' well as a mix of folders and files are permissible selections.
 #' 
+#' @param sort_by Defines what attribute the file list should be sorted by initially
+#' (the user can change it on the fly within the dialog afterwards). The options are 
+#' "Name", "Type", "Size", "Created" and "Modified". Defaults to "Name".
+#' 
+#' @param ascending A logical indicating whether sorting should be ascending (TRUE) or
+#' descending (FALSE). Defaults to sorting in "ascending" order.
+#' 
 #' @family shinyFiles
 #' 
 #' @references The file icons used in the file system navigator is taken from
@@ -242,7 +252,13 @@ shinyFileChoose <- function(input, id, updateFreq=2000, session, ...) {
 #' 
 #' @export
 #' 
-shinyFilesButton <- function(id, label, title, multiple, folder_select = FALSE) {
+shinyFilesButton <- function(id, label, title, multiple, folder_select = FALSE,
+                             sort_by = c("Name", "Type", "Size", "Created", "Modified"),
+                             ascending = TRUE) {
+    
+    if (missing(sort_by)) sort_by <- "Name"
+    sort_by <- match.arg(sort_by)
+    
     tagList(
         singleton(tags$head(
                 tags$script(src='sF/shinyFiles.js'),
@@ -264,6 +280,8 @@ shinyFilesButton <- function(id, label, title, multiple, folder_select = FALSE) 
             'data-title'=title,
             'data-selecttype'=ifelse(multiple, 'multiple', 'single'),
             'data-folderselect'=ifelse(folder_select, 'allowed', 'forbidden'),
+            'data-sortby'=sort_by,
+            'data-sortdirection'=ifelse(ascending, 'ascending', 'descending'),
             as.character(label)
             )
         )

--- a/inst/www/shinyFiles.js
+++ b/inst/www/shinyFiles.js
@@ -192,8 +192,8 @@ var shinyFiles = (function() {
 		var back = $(button).data('back') || [];
 		var forward = $(button).data('forward') || [];
 		var view = $(button).data('view') || '';
-		var sort = $(button).data('sort') || 'Name';
-		var sortDir = $(button).data('sortDir') || 'ascending';
+		var sort = $(button).data('sortby') || 'Name';
+		var sortDir = $(button).data('sortdirection') || 'ascending';
 		
 		$(button).data('back', back)
 			.data('forward', forward)
@@ -732,6 +732,10 @@ var shinyFiles = (function() {
 		toggleSelectButton(modal, folder_select);
 		
 		modal.data('currentData', data);
+        
+        // re-sort the files according to the user selected sorting options
+    	sortFiles(modal, $(element).data('sort'), $(element).data('sortDir'));
+        
 		$(modal).trigger('change');
 	};
 	

--- a/man/shinyFilesButton.Rd
+++ b/man/shinyFilesButton.Rd
@@ -4,7 +4,9 @@
 \alias{shinyFilesButton}
 \title{Create a button to summon the file system navigator}
 \usage{
-shinyFilesButton(id, label, title, multiple, folder_select = FALSE)
+shinyFilesButton(id, label, title, multiple, folder_select = FALSE,
+  sort_by = c("Name", "Type", "Size", "Created", "Modified"),
+  ascending = TRUE)
 }
 \arguments{
 \item{id}{The id matching the \code{\link{shinyFileChoose}}}
@@ -21,6 +23,13 @@ select multiple files}
 a folder in the file system navigator as the selection (default FALSE). If
 folder_select = TRUE in combination with multiple = TRUE, multiple folders as
 well as a mix of folders and files are permissible selections.}
+
+\item{sort_by}{Defines what attribute the file list should be sorted by initially
+(the user can change it on the fly within the dialog afterwards). The options are
+"Name", "Type", "Size", "Created" and "Modified". Defaults to "Name".}
+
+\item{ascending}{A logical indicating whether sorting should be ascending (TRUE) or
+descending (FALSE). Defaults to sorting in "ascending" order.}
 }
 \description{
 This function adds the required html markup for the client to access the file
@@ -45,13 +54,16 @@ a call to \code{\link{parseFilePaths}} for a more beautiful output.
 For users wanting to design their html markup manually it is very easy to add
 a shinyFiles button. The only markup required is:
 
-\code{<button id="inputId" type="button" class="shinyFiles btn" data-title="title" data-selecttype="single"|"multiple" data-folderselect="allowed"|"forbidden">label</button>}
+\code{<button id="inputId" type="button" class="shinyFiles btn" data-title="title" data-selecttype="single"|"multiple" data-folderselect="allowed"|"forbidden" data-sortby="Name"|"Type"|"Size"|"Created"|"Modified" data-sortdirection="ascending"|"descending">label</button>}
 
 where the id tag matches the inputId parameter, the data-title tag matches
 the title parameter, the data-selecttype is either "single" or "multiple" (
 the non-logical form of the multiple parameter), the data-folderselect is
 either "allowed" or "forbidden" (non-logical form of the folder_select
-parameter) and the internal textnode matches the label parameter.
+parameter), the data-sortby defines the attribute to sort by ("Name",
+"Type", "Size", "Created" or "Modified"), the data-sortdirection the
+sorting direction ("ascending" or "descending") and the internal textnode
+matches the label parameter.
 
 Apart from this the html document should link to a script with the
 following path 'sF/shinyFiles.js' and a stylesheet with the following path


### PR DESCRIPTION
- file sorting is reapplied after each folder switch according to the
  user selected sorting parameters
- iniitial file sorting options can be set more easily directly through
  the shinyFilesButton function:

Example:

```
shinyFilesButton('file', ‘File select', 'Please select a file’, FALSE,
sort_by = "Modified", ascending = FALSE)
```
